### PR TITLE
Make ErrorSummary non-static

### DIFF
--- a/src/main/java/reposense/model/CliRunConfiguration.java
+++ b/src/main/java/reposense/model/CliRunConfiguration.java
@@ -7,6 +7,7 @@ import java.util.logging.Logger;
 
 import reposense.parser.InvalidLocationException;
 import reposense.parser.ParseException;
+import reposense.report.ErrorSummary;
 import reposense.system.LogsManager;
 
 /**
@@ -31,7 +32,7 @@ public class CliRunConfiguration implements RunConfiguration {
         List<RepoConfiguration> configs = new ArrayList<>();
         for (String locationString : cliArguments.getLocations()) {
             try {
-                configs.add(new RepoConfiguration(new RepoLocation(locationString)));
+                configs.add(new RepoConfiguration(new RepoLocation(locationString, new ErrorSummary())));
             } catch (InvalidLocationException ile) {
                 logger.log(Level.WARNING, ile.getMessage(), ile);
             }

--- a/src/main/java/reposense/model/RepoLocation.java
+++ b/src/main/java/reposense/model/RepoLocation.java
@@ -55,18 +55,22 @@ public class RepoLocation {
     private final transient String outputFolderRepoName;
     private final transient String outputFolderOrganization;
 
+    private final ErrorSummary errorSummary;
+
     /**
      * Creates {@link RepoLocation} based on the {@code location}, which is represented by a {@code URL}
      * or {@link Path}.
      *
      * @throws InvalidLocationException if {@code location} cannot be represented by a {@code URL} or {@link Path}.
      */
-    public RepoLocation(String location) throws InvalidLocationException {
+    public RepoLocation(String location, ErrorSummary errorSummary) throws InvalidLocationException {
         if (SystemUtil.isWindows()) {
             location = StringsUtil.removeTrailingBackslash(location);
         }
 
         this.location = location;
+        this.errorSummary = errorSummary;
+
         String[] remoteRepoNameAndOrg;
         String[] outputFolderRepoNameAndOrg;
         if (location.isEmpty()) {
@@ -159,7 +163,7 @@ public class RepoLocation {
         Matcher localRepoMatcher = localRepoPattern.matcher(location);
 
         if (!localRepoMatcher.matches()) {
-            ErrorSummary.getInstance().addErrorMessage(location,
+            errorSummary.addErrorMessage(location,
                     String.format(MESSAGE_INVALID_LOCATION, location));
             throw new InvalidLocationException(String.format(MESSAGE_INVALID_LOCATION, location));
         }
@@ -185,14 +189,14 @@ public class RepoLocation {
             try {
                 new URI(location);
             } catch (URISyntaxException e) {
-                ErrorSummary.getInstance().addErrorMessage(location,
+                errorSummary.addErrorMessage(location,
                         String.format(MESSAGE_INVALID_REMOTE_URL, location));
                 throw new InvalidLocationException(String.format(MESSAGE_INVALID_REMOTE_URL, location));
             }
         }
         boolean isValidRemoteRepoUrl = remoteRepoMatcher.matches() || sshRepoMatcher.matches();
         if (!isValidRemoteRepoUrl) {
-            ErrorSummary.getInstance().addErrorMessage(location,
+            errorSummary.addErrorMessage(location,
                     String.format(MESSAGE_INVALID_REMOTE_URL, location));
             throw new InvalidLocationException(String.format(MESSAGE_INVALID_REMOTE_URL, location));
         }

--- a/src/main/java/reposense/parser/AuthorConfigCsvParser.java
+++ b/src/main/java/reposense/parser/AuthorConfigCsvParser.java
@@ -10,6 +10,7 @@ import org.apache.commons.csv.CSVRecord;
 import reposense.model.Author;
 import reposense.model.AuthorConfiguration;
 import reposense.model.RepoLocation;
+import reposense.report.ErrorSummary;
 
 /**
  * Container for the values parsed from {@code author-config.csv} file.
@@ -121,7 +122,7 @@ public class AuthorConfigCsvParser extends CsvParser<AuthorConfiguration> {
      */
     private static AuthorConfiguration findMatchingAuthorConfiguration(List<AuthorConfiguration> results,
             String location, String branch) throws InvalidLocationException {
-        AuthorConfiguration config = new AuthorConfiguration(new RepoLocation(location), branch);
+        AuthorConfiguration config = new AuthorConfiguration(new RepoLocation(location, new ErrorSummary()), branch);
 
         for (AuthorConfiguration authorConfig : results) {
             if (authorConfig.getLocation().equals(config.getLocation())

--- a/src/main/java/reposense/parser/GroupConfigCsvParser.java
+++ b/src/main/java/reposense/parser/GroupConfigCsvParser.java
@@ -9,6 +9,7 @@ import org.apache.commons.csv.CSVRecord;
 import reposense.model.FileType;
 import reposense.model.GroupConfiguration;
 import reposense.model.RepoLocation;
+import reposense.report.ErrorSummary;
 
 /**
  * Container for the values parsed from {@code group-config.csv} file.
@@ -78,7 +79,7 @@ public class GroupConfigCsvParser extends CsvParser<GroupConfiguration> {
      */
     private static GroupConfiguration findMatchingGroupConfiguration(List<GroupConfiguration> results,
             String location) throws InvalidLocationException {
-        GroupConfiguration config = new GroupConfiguration(new RepoLocation(location));
+        GroupConfiguration config = new GroupConfiguration(new RepoLocation(location, new ErrorSummary()));
 
         for (GroupConfiguration groupConfig : results) {
             if (groupConfig.getLocation().equals(config.getLocation())) {

--- a/src/main/java/reposense/parser/RepoConfigCsvParser.java
+++ b/src/main/java/reposense/parser/RepoConfigCsvParser.java
@@ -10,6 +10,7 @@ import reposense.model.CommitHash;
 import reposense.model.FileType;
 import reposense.model.RepoConfiguration;
 import reposense.model.RepoLocation;
+import reposense.report.ErrorSummary;
 import reposense.util.FileUtil;
 import reposense.util.StringsUtil;
 
@@ -78,7 +79,8 @@ public class RepoConfigCsvParser extends CsvParser<RepoConfiguration> {
     protected void processLine(List<RepoConfiguration> results, CSVRecord record) throws InvalidLocationException {
         // The variable expansion is performed to simulate running the same location from command line.
         // This helps to support things like tilde expansion and other Bash/CMD features.
-        RepoLocation location = new RepoLocation(FileUtil.getVariableExpandedFilePath(get(record, LOCATION_HEADER)));
+        RepoLocation location = new RepoLocation(
+                FileUtil.getVariableExpandedFilePath(get(record, LOCATION_HEADER)), new ErrorSummary());
         String branch = getOrDefault(record, BRANCH_HEADER, RepoConfiguration.DEFAULT_BRANCH);
 
         boolean isFormatsOverriding = isElementOverridingStandaloneConfig(record, FILE_FORMATS_HEADER);

--- a/src/main/java/reposense/report/ErrorSummary.java
+++ b/src/main/java/reposense/report/ErrorSummary.java
@@ -9,14 +9,10 @@ import java.util.Set;
  * Holds the data of set of repos that failed to analyze and the reasons for the failed operation.
  */
 public class ErrorSummary {
-    private static ErrorSummary instance = null;
-    private static Set<Map<String, String>> errorSet = new HashSet<>();
+    private Set<Map<String, String>> errorSet;
 
-    public static ErrorSummary getInstance() {
-        if (instance == null) {
-            instance = new ErrorSummary();
-        }
-        return instance;
+    public ErrorSummary() {
+        errorSet = new HashSet<>();
     }
 
     /**

--- a/src/main/java/reposense/report/ReportGenerator.java
+++ b/src/main/java/reposense/report/ReportGenerator.java
@@ -92,6 +92,8 @@ public class ReportGenerator {
     private LocalDateTime earliestSinceDate = null;
     private ProgressTracker progressTracker = null;
 
+    private ErrorSummary errorSummary = new ErrorSummary();
+
     /**
      * Generates the authorship and commits JSON file for each repo in {@code configs} at {@code outputPath}, as
      * well as the summary JSON file of all the repos.
@@ -135,7 +137,7 @@ public class ReportGenerator {
         Optional<Path> summaryPath = FileUtil.writeJsonFile(
                 new SummaryJson(configs, reportConfig, generationDate,
                         reportSinceDate, untilDate, isSinceDateProvided,
-                        isUntilDateProvided, RepoSense.getVersion(), ErrorSummary.getInstance().getErrorSet(),
+                        isUntilDateProvided, RepoSense.getVersion(), errorSummary.getErrorSet(),
                         reportGenerationTimeProvider.get(), zoneId),
                 getSummaryResultPath(outputPath));
         summaryPath.ifPresent(reportFoldersAndFiles::add);
@@ -456,7 +458,7 @@ public class ReportGenerator {
         while (itr.hasNext()) {
             RepoConfiguration config = itr.next();
             if (failedConfigs.contains(config)) {
-                ErrorSummary.getInstance().addErrorMessage(config.getDisplayName(), errorMessage);
+                errorSummary.addErrorMessage(config.getDisplayName(), errorMessage);
                 itr.remove();
             }
         }

--- a/src/systemtest/java/reposense/ConfigSystemTest.java
+++ b/src/systemtest/java/reposense/ConfigSystemTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 import reposense.git.GitVersion;
 import reposense.model.SupportedDomainUrlMap;
 import reposense.parser.SinceDateArgumentType;
-import reposense.report.ErrorSummary;
 import reposense.util.FileUtil;
 import reposense.util.InputBuilder;
 import reposense.util.SystemTestUtil;
@@ -39,7 +38,7 @@ public class ConfigSystemTest {
     public void setUp() throws Exception {
         SupportedDomainUrlMap.clearAccessedSet();
         FileUtil.deleteDirectory(OUTPUT_DIRECTORY);
-        ErrorSummary.getInstance().clearErrorSet();
+        // ErrorSummary.getInstance().clearErrorSet();
     }
 
     @AfterEach

--- a/src/systemtest/java/reposense/LocalRepoSystemTest.java
+++ b/src/systemtest/java/reposense/LocalRepoSystemTest.java
@@ -39,17 +39,19 @@ public class LocalRepoSystemTest {
 
     @BeforeAll
     public static void setupLocalRepos() throws Exception {
-        TestRepoCloner.clone(new RepoConfiguration(new RepoLocation("https://github.com/reposense/testrepo-Alpha")),
-                Paths.get("."), LOCAL_DIRECTORY_ONE);
-        TestRepoCloner.clone(new RepoConfiguration(new RepoLocation("https://github.com/reposense/testrepo-Alpha")),
-                Paths.get("."), LOCAL_DIRECTORY_TWO);
+        TestRepoCloner.clone(new RepoConfiguration(
+                new RepoLocation("https://github.com/reposense/testrepo-Alpha", new ErrorSummary())),
+                        Paths.get("."), LOCAL_DIRECTORY_ONE);
+        TestRepoCloner.clone(new RepoConfiguration(
+                new RepoLocation("https://github.com/reposense/testrepo-Alpha", new ErrorSummary())),
+                        Paths.get("."), LOCAL_DIRECTORY_TWO);
     }
 
     @BeforeEach
     public void setupLocalTest() throws Exception {
         SupportedDomainUrlMap.clearAccessedSet();
         FileUtil.deleteDirectory(OUTPUT_DIRECTORY);
-        ErrorSummary.getInstance().clearErrorSet();
+        // ErrorSummary.getInstance().clearErrorSet();
     }
 
     @AfterEach

--- a/src/test/java/reposense/git/GitBranchTest.java
+++ b/src/test/java/reposense/git/GitBranchTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import reposense.model.FileTypeTest;
 import reposense.model.RepoConfiguration;
 import reposense.model.RepoLocation;
+import reposense.report.ErrorSummary;
 import reposense.template.GitTestTemplate;
 import reposense.util.TestRepoCloner;
 
@@ -32,7 +33,8 @@ public class GitBranchTest extends GitTestTemplate {
     @Test
     public void getCurrentBranch_uncommonDefaultBranch_success() throws Exception {
         RepoConfiguration uncommonDefaultConfig = new RepoConfiguration(
-                new RepoLocation(TEST_REPO_UNCOMMON_DEFAULT_GIT_LOCATION), RepoConfiguration.DEFAULT_BRANCH);
+                new RepoLocation(TEST_REPO_UNCOMMON_DEFAULT_GIT_LOCATION, new ErrorSummary()),
+                        RepoConfiguration.DEFAULT_BRANCH);
         uncommonDefaultConfig.setFormats(FileTypeTest.DEFAULT_TEST_FORMATS);
         TestRepoCloner.cloneAndBranch(uncommonDefaultConfig);
         String currentBranch = GitBranch.getCurrentBranch(uncommonDefaultConfig.getRepoRoot());

--- a/src/test/java/reposense/model/RepoConfigurationTest.java
+++ b/src/test/java/reposense/model/RepoConfigurationTest.java
@@ -18,6 +18,7 @@ import reposense.parser.ArgsParser;
 import reposense.parser.AuthorConfigCsvParser;
 import reposense.parser.GroupConfigCsvParser;
 import reposense.parser.RepoConfigCsvParser;
+import reposense.report.ErrorSummary;
 import reposense.report.ReportGenerator;
 import reposense.util.InputBuilder;
 import reposense.util.TestRepoCloner;
@@ -110,7 +111,8 @@ public class RepoConfigurationTest {
         expectedAuthors.add(THIRD_AUTHOR);
         expectedAuthors.add(FOURTH_AUTHOR);
 
-        repoDeltaStandaloneConfig = new RepoConfiguration(new RepoLocation(TEST_REPO_DELTA), "master");
+        repoDeltaStandaloneConfig = new RepoConfiguration(
+                new RepoLocation(TEST_REPO_DELTA, new ErrorSummary()), "master");
         repoDeltaStandaloneConfig.setAuthorList(expectedAuthors);
         repoDeltaStandaloneConfig.addAuthorNamesToAuthorMapEntry(FIRST_AUTHOR, FIRST_AUTHOR_ALIASES);
         repoDeltaStandaloneConfig.addAuthorNamesToAuthorMapEntry(FOURTH_AUTHOR, FOURTH_AUTHOR_ALIASES);
@@ -130,7 +132,8 @@ public class RepoConfigurationTest {
 
     @Test
     public void repoConfig_usesStandaloneConfig_success() throws Exception {
-        RepoConfiguration actualConfig = new RepoConfiguration(new RepoLocation(TEST_REPO_DELTA), "master");
+        RepoConfiguration actualConfig = new RepoConfiguration(
+                new RepoLocation(TEST_REPO_DELTA, new ErrorSummary()), "master");
         TestRepoCloner.cloneAndBranch(actualConfig);
         reportGenerator.updateRepoConfig(actualConfig);
 
@@ -144,7 +147,8 @@ public class RepoConfigurationTest {
         author.setIgnoreGlobList(REPO_LEVEL_GLOB_LIST);
         expectedAuthors.add(author);
 
-        RepoConfiguration expectedConfig = new RepoConfiguration(new RepoLocation(TEST_REPO_DELTA), "master");
+        RepoConfiguration expectedConfig = new RepoConfiguration(
+                new RepoLocation(TEST_REPO_DELTA, new ErrorSummary()), "master");
         expectedConfig.setAuthorList(expectedAuthors);
         expectedConfig.addAuthorNamesToAuthorMapEntry(author, FIRST_AUTHOR_ALIASES);
         expectedConfig.setAuthorDisplayName(author, "Ahm");
@@ -174,7 +178,8 @@ public class RepoConfigurationTest {
 
     @Test
     public void repoConfig_ignoresStandaloneConfigInCli_success() throws Exception {
-        RepoConfiguration expectedConfig = new RepoConfiguration(new RepoLocation(TEST_REPO_DELTA), "master");
+        RepoConfiguration expectedConfig = new RepoConfiguration(
+                new RepoLocation(TEST_REPO_DELTA, new ErrorSummary()), "master");
         expectedConfig.setFormats(FileType.convertFormatStringsToFileTypes(CLI_FORMATS));
         expectedConfig.setStandaloneConfigIgnored(true);
 
@@ -202,11 +207,11 @@ public class RepoConfigurationTest {
     public void repoConfig_ignoreStandaloneConfigInCli_overrideCsv() throws Exception {
 
         RepoConfiguration repoBetaExpectedConfig = new RepoConfiguration(
-                new RepoLocation(TEST_REPO_BETA), "master");
+                new RepoLocation(TEST_REPO_BETA, new ErrorSummary()), "master");
         repoBetaExpectedConfig.setFormats(FileType.convertFormatStringsToFileTypes(CLI_FORMATS));
         repoBetaExpectedConfig.setStandaloneConfigIgnored(true);
         RepoConfiguration repoDeltaExpectedConfig = new RepoConfiguration(
-                new RepoLocation(TEST_REPO_DELTA), "master");
+                new RepoLocation(TEST_REPO_DELTA, new ErrorSummary()), "master");
         repoDeltaExpectedConfig.setStandaloneConfigIgnored(true);
 
         String input = new InputBuilder().addConfig(IGNORE_STANDALONE_FLAG_OVERRIDE_CSV_TEST)
@@ -230,7 +235,8 @@ public class RepoConfigurationTest {
 
     @Test
     public void repoConfig_ignoreFileSizeLimit_success() throws Exception {
-        RepoConfiguration expectedConfig = new RepoConfiguration(new RepoLocation(TEST_REPO_DELTA), "master");
+        RepoConfiguration expectedConfig = new RepoConfiguration(
+                new RepoLocation(TEST_REPO_DELTA, new ErrorSummary()), "master");
         expectedConfig.setIgnoreGlobList(REPO_LEVEL_GLOB_LIST);
         expectedConfig.setFormats(CONFIG_FORMATS);
         expectedConfig.setStandaloneConfigIgnored(true);
@@ -256,12 +262,12 @@ public class RepoConfigurationTest {
     @Test
     public void repoConfig_ignoreFileSizeLimitInCli_overrideCsv() throws Exception {
         RepoConfiguration repoBetaExpectedConfig = new RepoConfiguration(
-                new RepoLocation(TEST_REPO_BETA), "master");
+                new RepoLocation(TEST_REPO_BETA, new ErrorSummary()), "master");
         repoBetaExpectedConfig.setFormats(FileType.convertFormatStringsToFileTypes(CLI_FORMATS));
         repoBetaExpectedConfig.setStandaloneConfigIgnored(true);
         repoBetaExpectedConfig.setFileSizeLimitIgnored(true);
         RepoConfiguration repoDeltaExpectedConfig = new RepoConfiguration(
-                new RepoLocation(TEST_REPO_DELTA), "master");
+                new RepoLocation(TEST_REPO_DELTA, new ErrorSummary()), "master");
         repoDeltaExpectedConfig.setStandaloneConfigIgnored(true);
         repoDeltaExpectedConfig.setFileSizeLimitIgnored(true);
 
@@ -288,7 +294,7 @@ public class RepoConfigurationTest {
     @Test
     public void repoConfig_withoutIgnoreStandaloneConfigInCli_useCsv() throws Exception {
         RepoConfiguration repoBetaExpectedConfig = new RepoConfiguration(
-                new RepoLocation(TEST_REPO_BETA), "master");
+                new RepoLocation(TEST_REPO_BETA, new ErrorSummary()), "master");
         repoBetaExpectedConfig.setFormats(FileType.convertFormatStringsToFileTypes(CLI_FORMATS));
         repoBetaExpectedConfig.setStandaloneConfigIgnored(true);
 
@@ -329,7 +335,8 @@ public class RepoConfigurationTest {
 
     @Test
     public void repoConfig_shallowCloning_success() throws Exception {
-        RepoConfiguration expectedConfig = new RepoConfiguration(new RepoLocation(TEST_REPO_DELTA), "master");
+        RepoConfiguration expectedConfig = new RepoConfiguration(
+                new RepoLocation(TEST_REPO_DELTA, new ErrorSummary()), "master");
         expectedConfig.setIgnoreGlobList(REPO_LEVEL_GLOB_LIST);
         expectedConfig.setFormats(CONFIG_FORMATS);
         expectedConfig.setStandaloneConfigIgnored(true);
@@ -354,7 +361,8 @@ public class RepoConfigurationTest {
 
     @Test
     public void repoConfig_shallowCloningInCli_success() throws Exception {
-        RepoConfiguration expectedConfig = new RepoConfiguration(new RepoLocation(TEST_REPO_DELTA), "master");
+        RepoConfiguration expectedConfig = new RepoConfiguration(
+                new RepoLocation(TEST_REPO_DELTA, new ErrorSummary()), "master");
         expectedConfig.setFormats(FileType.convertFormatStringsToFileTypes(CLI_FORMATS));
         expectedConfig.setStandaloneConfigIgnored(true);
         expectedConfig.setIsShallowCloningPerformed(true);
@@ -383,12 +391,12 @@ public class RepoConfigurationTest {
     @Test
     public void repoConfig_shallowCloningInCli_overrideCsv() throws Exception {
         RepoConfiguration repoBetaExpectedConfig = new RepoConfiguration(
-                new RepoLocation(TEST_REPO_BETA), "master");
+                new RepoLocation(TEST_REPO_BETA, new ErrorSummary()), "master");
         repoBetaExpectedConfig.setFormats(FileType.convertFormatStringsToFileTypes(CLI_FORMATS));
         repoBetaExpectedConfig.setStandaloneConfigIgnored(true);
         repoBetaExpectedConfig.setIsShallowCloningPerformed(true);
         RepoConfiguration repoDeltaExpectedConfig = new RepoConfiguration(
-                new RepoLocation(TEST_REPO_DELTA), "master");
+                new RepoLocation(TEST_REPO_DELTA, new ErrorSummary()), "master");
         repoDeltaExpectedConfig.setStandaloneConfigIgnored(true);
         repoDeltaExpectedConfig.setIsShallowCloningPerformed(true);
 
@@ -415,12 +423,12 @@ public class RepoConfigurationTest {
     @Test
     public void repoConfig_withoutShallowCloningInInCli_useCsv() throws Exception {
         RepoConfiguration repoBetaExpectedConfig = new RepoConfiguration(
-                new RepoLocation(TEST_REPO_BETA), "master");
+                new RepoLocation(TEST_REPO_BETA, new ErrorSummary()), "master");
         repoBetaExpectedConfig.setFormats(FileType.convertFormatStringsToFileTypes(CLI_FORMATS));
         repoBetaExpectedConfig.setStandaloneConfigIgnored(true);
         repoBetaExpectedConfig.setIsShallowCloningPerformed(true);
         RepoConfiguration repoDeltaExpectedConfig = new RepoConfiguration(
-                new RepoLocation(TEST_REPO_DELTA), "master");
+                new RepoLocation(TEST_REPO_DELTA, new ErrorSummary()), "master");
         repoDeltaExpectedConfig.setStandaloneConfigIgnored(true);
 
         String input = new InputBuilder().addConfig(SHALLOW_CLONING_FLAG_OVERRIDE_TEST_CONFIG_FILES).build();
@@ -443,7 +451,8 @@ public class RepoConfigurationTest {
 
     @Test
     public void repoConfig_findPreviousAuthors_success() throws Exception {
-        RepoConfiguration expectedConfig = new RepoConfiguration(new RepoLocation(TEST_REPO_DELTA), "master");
+        RepoConfiguration expectedConfig = new RepoConfiguration(
+                new RepoLocation(TEST_REPO_DELTA, new ErrorSummary()), "master");
         expectedConfig.setIgnoreGlobList(REPO_LEVEL_GLOB_LIST);
         expectedConfig.setFormats(CONFIG_FORMATS);
         expectedConfig.setStandaloneConfigIgnored(true);
@@ -468,7 +477,8 @@ public class RepoConfigurationTest {
 
     @Test
     public void repoConfig_findPreviousAuthorsInCli_success() throws Exception {
-        RepoConfiguration expectedConfig = new RepoConfiguration(new RepoLocation(TEST_REPO_DELTA), "master");
+        RepoConfiguration expectedConfig = new RepoConfiguration(
+                new RepoLocation(TEST_REPO_DELTA, new ErrorSummary()), "master");
         expectedConfig.setFormats(FileType.convertFormatStringsToFileTypes(CLI_FORMATS));
         expectedConfig.setStandaloneConfigIgnored(true);
         expectedConfig.setIsFindingPreviousAuthorsPerformed(true);
@@ -497,12 +507,12 @@ public class RepoConfigurationTest {
     @Test
     public void repoConfig_findPreviousAuthorsInCli_overrideCsv() throws Exception {
         RepoConfiguration repoBetaExpectedConfig = new RepoConfiguration(
-                new RepoLocation(TEST_REPO_BETA), "master");
+                new RepoLocation(TEST_REPO_BETA, new ErrorSummary()), "master");
         repoBetaExpectedConfig.setFormats(FileType.convertFormatStringsToFileTypes(CLI_FORMATS));
         repoBetaExpectedConfig.setStandaloneConfigIgnored(true);
         repoBetaExpectedConfig.setIsFindingPreviousAuthorsPerformed(true);
         RepoConfiguration repoDeltaExpectedConfig = new RepoConfiguration(
-                new RepoLocation(TEST_REPO_DELTA), "master");
+                new RepoLocation(TEST_REPO_DELTA, new ErrorSummary()), "master");
         repoDeltaExpectedConfig.setStandaloneConfigIgnored(true);
         repoDeltaExpectedConfig.setIsFindingPreviousAuthorsPerformed(true);
 
@@ -529,12 +539,12 @@ public class RepoConfigurationTest {
     @Test
     public void repoConfig_withoutFindPreviousAuthorsInCli_useCsv() throws Exception {
         RepoConfiguration repoBetaExpectedConfig = new RepoConfiguration(
-                new RepoLocation(TEST_REPO_BETA), "master");
+                new RepoLocation(TEST_REPO_BETA, new ErrorSummary()), "master");
         repoBetaExpectedConfig.setFormats(FileType.convertFormatStringsToFileTypes(CLI_FORMATS));
         repoBetaExpectedConfig.setStandaloneConfigIgnored(true);
         repoBetaExpectedConfig.setIsFindingPreviousAuthorsPerformed(true);
         RepoConfiguration repoDeltaExpectedConfig = new RepoConfiguration(
-                new RepoLocation(TEST_REPO_DELTA), "master");
+                new RepoLocation(TEST_REPO_DELTA, new ErrorSummary()), "master");
         repoDeltaExpectedConfig.setStandaloneConfigIgnored(true);
 
         String input = new InputBuilder().addConfig(FIND_PREVIOUS_AUTHORS_FLAG_OVERRIDE_TEST_CONFIG_FILES).build();
@@ -559,11 +569,11 @@ public class RepoConfigurationTest {
     public void repoConfig_userEnvironmentCannotRunFindPreviousAuthors_setFindPreviousAuthorsToFalseInAllRepoConfigs()
             throws Exception {
         RepoConfiguration repoBetaExpectedConfig = new RepoConfiguration(
-                new RepoLocation(TEST_REPO_BETA), "master");
+                new RepoLocation(TEST_REPO_BETA, new ErrorSummary()), "master");
         repoBetaExpectedConfig.setFormats(FileType.convertFormatStringsToFileTypes(CLI_FORMATS));
         repoBetaExpectedConfig.setStandaloneConfigIgnored(true);
         RepoConfiguration repoDeltaExpectedConfig = new RepoConfiguration(
-                new RepoLocation(TEST_REPO_DELTA), "master");
+                new RepoLocation(TEST_REPO_DELTA, new ErrorSummary()), "master");
         repoDeltaExpectedConfig.setStandaloneConfigIgnored(true);
 
         String input = new InputBuilder().addConfig(FIND_PREVIOUS_AUTHORS_FLAG_OVERRIDE_TEST_CONFIG_FILES).build();
@@ -654,9 +664,12 @@ public class RepoConfigurationTest {
 
     @Test
     public void repoConfig_emptyLocationDifferentBranch_equal() throws Exception {
-        RepoConfiguration emptyLocationEmptyBranchRepoConfig = new RepoConfiguration(new RepoLocation(""), "");
-        RepoConfiguration emptyLocationDefaultBranchRepoConfig = new RepoConfiguration(new RepoLocation(""));
-        RepoConfiguration emptyLocationWithBranchRepoConfig = new RepoConfiguration(new RepoLocation(""), "master");
+        RepoConfiguration emptyLocationEmptyBranchRepoConfig = new RepoConfiguration(
+                new RepoLocation("", new ErrorSummary()), "");
+        RepoConfiguration emptyLocationDefaultBranchRepoConfig = new RepoConfiguration(
+                new RepoLocation("", new ErrorSummary()));
+        RepoConfiguration emptyLocationWithBranchRepoConfig = new RepoConfiguration(
+                new RepoLocation("", new ErrorSummary()), "master");
 
         Assertions.assertEquals(emptyLocationDefaultBranchRepoConfig, emptyLocationEmptyBranchRepoConfig);
         Assertions.assertEquals(emptyLocationWithBranchRepoConfig, emptyLocationEmptyBranchRepoConfig);
@@ -664,17 +677,18 @@ public class RepoConfigurationTest {
 
     @Test
     public void repoConfig_sameLocationDifferentBranch_notEqual() throws Exception {
-        RepoConfiguration validLocationValidBranchRepoConfig =
-                new RepoConfiguration(new RepoLocation(TEST_REPO_DELTA), "master");
-        RepoConfiguration validLocationDefaultBranchRepoConfig =
-                new RepoConfiguration(new RepoLocation(TEST_REPO_DELTA));
+        RepoConfiguration validLocationValidBranchRepoConfig = new RepoConfiguration(
+                new RepoLocation(TEST_REPO_DELTA, new ErrorSummary()), "master");
+        RepoConfiguration validLocationDefaultBranchRepoConfig = new RepoConfiguration(
+                new RepoLocation(TEST_REPO_DELTA, new ErrorSummary()));
 
         Assertions.assertNotEquals(validLocationDefaultBranchRepoConfig, validLocationValidBranchRepoConfig);
     }
 
     @Test
     public void repoConfig_overrideStandaloneConfig_success() throws Exception {
-        RepoConfiguration expectedConfig = new RepoConfiguration(new RepoLocation(TEST_REPO_DELTA), "master",
+        RepoConfiguration expectedConfig = new RepoConfiguration(
+                new RepoLocation(TEST_REPO_DELTA, new ErrorSummary()), "master",
                 Collections.emptyList(), Collections.emptyList(), RepoConfiguration.DEFAULT_FILE_SIZE_LIMIT, false,
                 false, Collections.emptyList(), true, true, true, false, false, false, false,
                 Arrays.asList("lithiumlkid"), true);
@@ -714,7 +728,8 @@ public class RepoConfigurationTest {
 
     @Test
     public void repoConfig_minimalStandaloneConfig_fieldsAssignedDefaultValues() throws Exception {
-        RepoConfiguration expectedConfig = new RepoConfiguration(new RepoLocation(TEST_REPO_MINIMAL_STANDALONE_CONFIG),
+        RepoConfiguration expectedConfig = new RepoConfiguration(
+                new RepoLocation(TEST_REPO_MINIMAL_STANDALONE_CONFIG, new ErrorSummary()),
                 "master");
 
         Author firstAuthor = new Author("bluein-green");
@@ -726,7 +741,8 @@ public class RepoConfigurationTest {
         expectedConfig.setFormats(Collections.emptyList());
         expectedConfig.setIgnoreCommitList(Collections.emptyList());
 
-        RepoConfiguration actualConfig = new RepoConfiguration(new RepoLocation(TEST_REPO_MINIMAL_STANDALONE_CONFIG),
+        RepoConfiguration actualConfig = new RepoConfiguration(
+                new RepoLocation(TEST_REPO_MINIMAL_STANDALONE_CONFIG, new ErrorSummary()),
                 "master");
         TestRepoCloner.cloneAndBranch(actualConfig);
         reportGenerator.updateRepoConfig(actualConfig);
@@ -741,7 +757,8 @@ public class RepoConfigurationTest {
         author.setIgnoreGlobList(REPO_LEVEL_GLOB_LIST);
         expectedAuthors.add(author);
 
-        RepoConfiguration expectedConfig = new RepoConfiguration(new RepoLocation(TEST_REPO_DELTA), "master");
+        RepoConfiguration expectedConfig = new RepoConfiguration(
+                new RepoLocation(TEST_REPO_DELTA, new ErrorSummary()), "master");
         expectedConfig.setAuthorList(expectedAuthors);
         expectedConfig.addAuthorNamesToAuthorMapEntry(author, FIRST_AUTHOR_ALIASES);
         expectedConfig.setAuthorDisplayName(author, "Ahm");

--- a/src/test/java/reposense/model/RepoLocationTest.java
+++ b/src/test/java/reposense/model/RepoLocationTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 
 import reposense.parser.InvalidLocationException;
+import reposense.report.ErrorSummary;
 import reposense.util.AssertUtil;
 import reposense.util.SystemUtil;
 
@@ -38,7 +39,7 @@ public class RepoLocationTest {
 
     @Test
     public void repoLocation_parseEmptyString_success() throws Exception {
-        RepoLocation repoLocation = new RepoLocation("");
+        RepoLocation repoLocation = new RepoLocation("", new ErrorSummary());
     }
 
     @Test
@@ -196,13 +197,14 @@ public class RepoLocationTest {
      */
     public void assertParsableLocation(String rawLocation, String expectedRepoName,
             String expectedOrganization, String expectedDomainName) throws Exception {
-        RepoLocation repoLocation = new RepoLocation(rawLocation);
+        RepoLocation repoLocation = new RepoLocation(rawLocation, new ErrorSummary());
         Assertions.assertEquals(expectedRepoName, repoLocation.getRepoName());
         Assertions.assertEquals(expectedOrganization, repoLocation.getOrganization());
         Assertions.assertEquals(expectedDomainName, repoLocation.getDomainName());
     }
 
     private void assertUnparsableLocation(String rawLocation) {
-        AssertUtil.assertThrows(InvalidLocationException.class, () -> new RepoLocation(rawLocation));
+        AssertUtil.assertThrows(InvalidLocationException.class, () ->
+                new RepoLocation(rawLocation, new ErrorSummary()));
     }
 }

--- a/src/test/java/reposense/parser/AuthorConfigParserTest.java
+++ b/src/test/java/reposense/parser/AuthorConfigParserTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import reposense.model.Author;
 import reposense.model.AuthorConfiguration;
 import reposense.model.RepoLocation;
+import reposense.report.ErrorSummary;
 
 public class AuthorConfigParserTest {
     private static final Path AUTHOR_CONFIG_EMPTY_LOCATION_FILE = loadResource(AuthorConfigParserTest.class,
@@ -104,7 +105,7 @@ public class AuthorConfigParserTest {
 
         AuthorConfiguration config = configs.get(0);
 
-        Assertions.assertEquals(new RepoLocation(TEST_REPO_BETA_LOCATION), config.getLocation());
+        Assertions.assertEquals(new RepoLocation(TEST_REPO_BETA_LOCATION, new ErrorSummary()), config.getLocation());
         Assertions.assertEquals(TEST_REPO_BETA_MASTER_BRANCH, config.getBranch());
 
         Assertions.assertEquals(AUTHOR_CONFIG_NO_SPECIAL_CHARACTER_AUTHORS, config.getAuthorList());
@@ -112,7 +113,7 @@ public class AuthorConfigParserTest {
 
     @Test
     public void authorConfig_emptyLocation_success() throws Exception {
-        AuthorConfiguration expectedConfig = new AuthorConfiguration(new RepoLocation(""));
+        AuthorConfiguration expectedConfig = new AuthorConfiguration(new RepoLocation("", new ErrorSummary()));
 
         AuthorConfigCsvParser authorConfigCsvParser = new AuthorConfigCsvParser(AUTHOR_CONFIG_EMPTY_LOCATION_FILE);
         List<AuthorConfiguration> authorConfigs = authorConfigCsvParser.parse();
@@ -139,7 +140,7 @@ public class AuthorConfigParserTest {
 
         AuthorConfiguration config = configs.get(0);
 
-        Assertions.assertEquals(new RepoLocation(TEST_REPO_BETA_LOCATION), config.getLocation());
+        Assertions.assertEquals(new RepoLocation(TEST_REPO_BETA_LOCATION, new ErrorSummary()), config.getLocation());
         Assertions.assertEquals(TEST_REPO_BETA_MASTER_BRANCH, config.getBranch());
 
         Assertions.assertEquals(AUTHOR_CONFIG_SPECIAL_CHARACTER_AUTHORS, config.getAuthorList());
@@ -169,7 +170,7 @@ public class AuthorConfigParserTest {
 
         AuthorConfiguration config = configs.get(0);
 
-        Assertions.assertEquals(new RepoLocation(TEST_REPO_BETA_LOCATION), config.getLocation());
+        Assertions.assertEquals(new RepoLocation(TEST_REPO_BETA_LOCATION, new ErrorSummary()), config.getLocation());
         Assertions.assertEquals(TEST_REPO_BETA_MASTER_BRANCH, config.getBranch());
 
         Assertions.assertEquals(AUTHOR_CONFIG_NO_SPECIAL_CHARACTER_AUTHORS, config.getAuthorList());
@@ -222,7 +223,7 @@ public class AuthorConfigParserTest {
 
         AuthorConfiguration config = configs.get(0);
 
-        Assertions.assertEquals(new RepoLocation(TEST_REPO_BETA_LOCATION), config.getLocation());
+        Assertions.assertEquals(new RepoLocation(TEST_REPO_BETA_LOCATION, new ErrorSummary()), config.getLocation());
         Assertions.assertEquals(TEST_REPO_BETA_MASTER_BRANCH, config.getBranch());
         Assertions.assertEquals(AUTHOR_DISPLAY_NAME_COMMAS_AND_DOUBLE_QUOTES_MAP, config.getAuthorDisplayNameMap());
 
@@ -242,19 +243,27 @@ public class AuthorConfigParserTest {
         Assertions.assertEquals(4, configs.size());
 
         AuthorConfiguration config = configs.get(0);
-        Assertions.assertEquals(new RepoLocation("https://github.com/reposense/reposense.git"), config.getLocation());
+        Assertions.assertEquals(
+                new RepoLocation("https://github.com/reposense/reposense.git", new ErrorSummary()),
+                config.getLocation());
         Assertions.assertEquals(defaultSpecifiedBranch, config.getBranch());
 
         config = configs.get(1);
-        Assertions.assertEquals(new RepoLocation("https://github.com/markbind/markbind.git"), config.getLocation());
+        Assertions.assertEquals(
+                new RepoLocation("https://github.com/markbind/markbind.git", new ErrorSummary()),
+                config.getLocation());
         Assertions.assertEquals(defaultSpecifiedBranch, config.getBranch());
 
         config = configs.get(2);
-        Assertions.assertEquals(new RepoLocation("https://github.com/TEAMMATES/teammates.git"), config.getLocation());
+        Assertions.assertEquals(
+                new RepoLocation("https://github.com/TEAMMATES/teammates.git", new ErrorSummary()),
+                config.getLocation());
         Assertions.assertEquals(defaultSpecifiedBranch, config.getBranch());
 
         config = configs.get(3);
-        Assertions.assertEquals(new RepoLocation("https://github.com/CATcher-org/CATcher.git"), config.getLocation());
+        Assertions.assertEquals(
+                new RepoLocation("https://github.com/CATcher-org/CATcher.git", new ErrorSummary()),
+                config.getLocation());
         Assertions.assertEquals(defaultSpecifiedBranch, config.getBranch());
     }
 
@@ -267,19 +276,20 @@ public class AuthorConfigParserTest {
         Assertions.assertEquals(4, configs.size());
 
         AuthorConfiguration config = configs.get(0);
-        Assertions.assertEquals(new RepoLocation(TEST_REPO_BETA_LOCATION), config.getLocation());
+        Assertions.assertEquals(new RepoLocation(TEST_REPO_BETA_LOCATION, new ErrorSummary()), config.getLocation());
         Assertions.assertEquals(TEST_REPO_BETA_MASTER_BRANCH, config.getBranch());
 
         config = configs.get(1);
-        Assertions.assertEquals(new RepoLocation(TEST_REPO_BETA_LOCATION), config.getLocation());
+        Assertions.assertEquals(new RepoLocation(TEST_REPO_BETA_LOCATION, new ErrorSummary()), config.getLocation());
         Assertions.assertEquals("add-config-json", config.getBranch());
 
         config = configs.get(2);
-        Assertions.assertEquals(new RepoLocation("https://github.com/reposense/RepoSense.git"), config.getLocation());
+        Assertions.assertEquals(new RepoLocation("https://github.com/reposense/RepoSense.git", new ErrorSummary()),
+                config.getLocation());
         Assertions.assertEquals("release", config.getBranch());
 
         config = configs.get(3);
-        Assertions.assertEquals(new RepoLocation("/Users/sikai/RepoSense"), config.getLocation());
+        Assertions.assertEquals(new RepoLocation("/Users/sikai/RepoSense", new ErrorSummary()), config.getLocation());
         Assertions.assertEquals("master", config.getBranch());
     }
 
@@ -292,23 +302,28 @@ public class AuthorConfigParserTest {
         Assertions.assertEquals(5, configs.size());
 
         AuthorConfiguration config = configs.get(0);
-        Assertions.assertEquals(new RepoLocation(TEST_REPO_BETA_LOCATION), config.getLocation());
+        Assertions.assertEquals(new RepoLocation(TEST_REPO_BETA_LOCATION,
+                new ErrorSummary()), config.getLocation());
         Assertions.assertEquals("add-config-json", config.getBranch());
 
         config = configs.get(1);
-        Assertions.assertEquals(new RepoLocation(TEST_REPO_BETA_LOCATION), config.getLocation());
+        Assertions.assertEquals(new RepoLocation(TEST_REPO_BETA_LOCATION,
+                new ErrorSummary()), config.getLocation());
         Assertions.assertEquals(TEST_REPO_BETA_MASTER_BRANCH, config.getBranch());
 
         config = configs.get(2);
-        Assertions.assertEquals(new RepoLocation("/Users/sikai/RepoSense"), config.getLocation());
+        Assertions.assertEquals(new RepoLocation("/Users/sikai/RepoSense",
+                new ErrorSummary()), config.getLocation());
         Assertions.assertEquals("master", config.getBranch());
 
         config = configs.get(3);
-        Assertions.assertEquals(new RepoLocation("/Users/sikai/RepoSense"), config.getLocation());
+        Assertions.assertEquals(new RepoLocation("/Users/sikai/RepoSense",
+                new ErrorSummary()), config.getLocation());
         Assertions.assertEquals("release", config.getBranch());
 
         config = configs.get(4);
-        Assertions.assertEquals(new RepoLocation("/Users/sikai/RepoSense"), config.getLocation());
+        Assertions.assertEquals(new RepoLocation("/Users/sikai/RepoSense",
+                new ErrorSummary()), config.getLocation());
         Assertions.assertEquals("gh-pages", config.getBranch());
     }
 }

--- a/src/test/java/reposense/parser/RepoConfigParserTest.java
+++ b/src/test/java/reposense/parser/RepoConfigParserTest.java
@@ -19,6 +19,7 @@ import reposense.model.CommitHash;
 import reposense.model.FileType;
 import reposense.model.RepoConfiguration;
 import reposense.model.RepoLocation;
+import reposense.report.ErrorSummary;
 import reposense.util.InputBuilder;
 import reposense.util.TestUtil;
 
@@ -94,7 +95,7 @@ public class RepoConfigParserTest {
 
         RepoConfiguration config = configs.get(0);
 
-        Assertions.assertEquals(new RepoLocation(TEST_REPO_BETA_LOCATION), config.getLocation());
+        Assertions.assertEquals(new RepoLocation(TEST_REPO_BETA_LOCATION, new ErrorSummary()), config.getLocation());
         Assertions.assertEquals(TEST_REPO_BETA_MASTER_BRANCH, config.getBranch());
 
         Assertions.assertEquals(TEST_REPO_BETA_CONFIG_FORMATS, config.getFileTypeManager().getFormats());
@@ -125,7 +126,8 @@ public class RepoConfigParserTest {
         expectedAuthors.add(FIRST_AUTHOR);
         expectedAuthors.add(SECOND_AUTHOR);
 
-        RepoConfiguration firstRepo = new RepoConfiguration(new RepoLocation(TEST_REPO_BETA_LOCATION),
+        RepoConfiguration firstRepo = new RepoConfiguration(
+                new RepoLocation(TEST_REPO_BETA_LOCATION, new ErrorSummary()),
                 TEST_REPO_BETA_MASTER_BRANCH);
         firstRepo.setAuthorList(expectedAuthors);
         firstRepo.setAuthorDisplayName(FIRST_AUTHOR, "Nbr");
@@ -133,7 +135,8 @@ public class RepoConfigParserTest {
         firstRepo.addAuthorNamesToAuthorMapEntry(SECOND_AUTHOR, Arrays.asList("Zachary Tang"));
         firstRepo.setIgnoreGlobList(REPO_LEVEL_GLOB_LIST);
 
-        RepoConfiguration secondRepo = new RepoConfiguration(new RepoLocation(TEST_REPO_BETA_LOCATION),
+        RepoConfiguration secondRepo = new RepoConfiguration(
+                new RepoLocation(TEST_REPO_BETA_LOCATION, new ErrorSummary()),
                 TEST_REPO_BETA_ADD_CONFIG_JSON_BRANCH);
         secondRepo.setAuthorList(Arrays.asList(SECOND_AUTHOR));
         secondRepo.setAuthorDisplayName(SECOND_AUTHOR, "Zac");
@@ -168,7 +171,8 @@ public class RepoConfigParserTest {
         expectedDeltaAuthors.add(FIRST_AUTHOR);
 
         RepoConfiguration expectedBetaConfig =
-                new RepoConfiguration(new RepoLocation(TEST_REPO_BETA_LOCATION), TEST_REPO_BETA_MASTER_BRANCH);
+                new RepoConfiguration(new RepoLocation(TEST_REPO_BETA_LOCATION, new ErrorSummary()),
+                        TEST_REPO_BETA_MASTER_BRANCH);
         expectedBetaConfig.setAuthorList(expectedBetaAuthors);
         expectedBetaConfig.setAuthorDisplayName(FIRST_AUTHOR, "Nbr");
         expectedBetaConfig.setAuthorDisplayName(SECOND_AUTHOR, "Zac");
@@ -177,7 +181,8 @@ public class RepoConfigParserTest {
         expectedBetaConfig.setIsShallowCloningPerformed(true);
 
         RepoConfiguration expectedDeltaConfig =
-                new RepoConfiguration(new RepoLocation(TEST_REPO_DELTA_LOCATION), TEST_REPO_DELTA_BRANCH);
+                new RepoConfiguration(new RepoLocation(TEST_REPO_DELTA_LOCATION, new ErrorSummary()),
+                        TEST_REPO_DELTA_BRANCH);
         expectedDeltaConfig.setAuthorList(expectedDeltaAuthors);
         expectedDeltaConfig.setAuthorDisplayName(FIRST_AUTHOR, "Nbr");
         expectedDeltaConfig.setStandaloneConfigIgnored(true);
@@ -205,8 +210,9 @@ public class RepoConfigParserTest {
 
     @Test
     public void repoConfig_defaultBranch_success() throws Exception {
-        RepoConfiguration expectedConfig = new RepoConfiguration(new RepoLocation(TEST_REPO_BETA_LOCATION),
-                RepoConfiguration.DEFAULT_BRANCH);
+        RepoConfiguration expectedConfig = new RepoConfiguration(
+                new RepoLocation(TEST_REPO_BETA_LOCATION, new ErrorSummary()),
+                        RepoConfiguration.DEFAULT_BRANCH);
 
         String input = new InputBuilder().addConfig(TEST_EMPTY_BRANCH_CONFIG_FOLDER).build();
         CliArguments cliArguments = ArgsParser.parse(translateCommandline(input));
@@ -229,7 +235,7 @@ public class RepoConfigParserTest {
         RepoConfiguration config = configs.get(0);
 
         Assertions.assertEquals(1, configs.size());
-        Assertions.assertEquals(new RepoLocation(TEST_REPO_BETA_LOCATION), config.getLocation());
+        Assertions.assertEquals(new RepoLocation(TEST_REPO_BETA_LOCATION, new ErrorSummary()), config.getLocation());
         Assertions.assertEquals(TEST_REPO_BETA_MASTER_BRANCH, config.getBranch());
         Assertions.assertEquals(TEST_REPO_BETA_CONFIG_FORMATS, config.getFileTypeManager().getFormats());
         Assertions.assertFalse(config.isStandaloneConfigIgnored());
@@ -253,11 +259,14 @@ public class RepoConfigParserTest {
         RepoConfiguration charlieConfig = configs.get(1);
         RepoConfiguration deltaConfig = configs.get(2);
 
-        Assertions.assertEquals(new RepoLocation(TEST_REPO_BETA_LOCATION), betaConfig.getLocation());
+        Assertions.assertEquals(new RepoLocation(TEST_REPO_BETA_LOCATION, new ErrorSummary()),
+                betaConfig.getLocation());
         Assertions.assertEquals(TEST_REPO_BETA_MASTER_BRANCH, betaConfig.getBranch());
-        Assertions.assertEquals(new RepoLocation(TEST_REPO_CHARLIE_LOCATION), charlieConfig.getLocation());
+        Assertions.assertEquals(new RepoLocation(TEST_REPO_CHARLIE_LOCATION, new ErrorSummary()),
+                charlieConfig.getLocation());
         Assertions.assertEquals(TEST_REPO_CHARLIE_BRANCH, charlieConfig.getBranch());
-        Assertions.assertEquals(new RepoLocation(TEST_REPO_DELTA_LOCATION), deltaConfig.getLocation());
+        Assertions.assertEquals(new RepoLocation(TEST_REPO_DELTA_LOCATION, new ErrorSummary()),
+                deltaConfig.getLocation());
         Assertions.assertEquals(TEST_REPO_DELTA_BRANCH, deltaConfig.getBranch());
         Assertions.assertTrue(deltaConfig.isStandaloneConfigIgnored());
     }
@@ -271,7 +280,7 @@ public class RepoConfigParserTest {
 
         RepoConfiguration config = configs.get(0);
 
-        Assertions.assertEquals(new RepoLocation(TEST_REPO_BETA_LOCATION), config.getLocation());
+        Assertions.assertEquals(new RepoLocation(TEST_REPO_BETA_LOCATION, new ErrorSummary()), config.getLocation());
         Assertions.assertEquals(TEST_REPO_BETA_MASTER_BRANCH, config.getBranch());
 
         Assertions.assertEquals(TEST_REPO_BETA_CONFIG_FORMATS, config.getFileTypeManager().getFormats());
@@ -295,7 +304,8 @@ public class RepoConfigParserTest {
 
         RepoConfiguration config = configs.get(0);
 
-        Assertions.assertEquals(new RepoLocation(TEST_REPO_BETA_LOCATION), config.getLocation());
+        Assertions.assertEquals(new RepoLocation(TEST_REPO_BETA_LOCATION, new ErrorSummary()),
+                config.getLocation());
         Assertions.assertEquals(TEST_REPO_BETA_MASTER_BRANCH, config.getBranch());
 
         Assertions.assertEquals(TEST_REPO_BETA_CONFIG_FORMATS, config.getFileTypeManager().getFormats());

--- a/src/test/java/reposense/parser/StandaloneConfigJsonParserTest.java
+++ b/src/test/java/reposense/parser/StandaloneConfigJsonParserTest.java
@@ -18,6 +18,7 @@ import reposense.model.FileTypeTest;
 import reposense.model.RepoConfiguration;
 import reposense.model.RepoLocation;
 import reposense.model.StandaloneConfig;
+import reposense.report.ErrorSummary;
 import reposense.util.TestUtil;
 
 public class StandaloneConfigJsonParserTest {
@@ -56,12 +57,13 @@ public class StandaloneConfigJsonParserTest {
         author.setAuthorAliases(Arrays.asList("Yong Hao TENG"));
         author.setIgnoreGlobList(Arrays.asList("**.css", "**.html", "**.jade", "**.js"));
 
-        expectedGithubIdOnlyRepoconfig = new RepoConfiguration(new RepoLocation(TEST_DUMMY_LOCATION));
+        expectedGithubIdOnlyRepoconfig = new RepoConfiguration(
+                new RepoLocation(TEST_DUMMY_LOCATION, new ErrorSummary()));
         expectedGithubIdOnlyRepoconfig.setFormats(FileTypeTest.NO_SPECIFIED_FORMATS);
         expectedGithubIdOnlyRepoconfig.setAuthorList(Arrays.asList(new Author("yong24s")));
         expectedGithubIdOnlyRepoconfig.addAuthorEmailsToAuthorMapEntry(author, author.getEmails());
 
-        expectedFullRepoConfig = new RepoConfiguration(new RepoLocation(TEST_DUMMY_LOCATION));
+        expectedFullRepoConfig = new RepoConfiguration(new RepoLocation(TEST_DUMMY_LOCATION, new ErrorSummary()));
         expectedFullRepoConfig.setFormats(FileType.convertFormatStringsToFileTypes(
                 Arrays.asList("gradle", "jade", "java", "js", "md", "scss", "yml")));
         expectedFullRepoConfig.setIgnoreCommitList(Arrays.asList(new CommitHash(
@@ -110,7 +112,8 @@ public class StandaloneConfigJsonParserTest {
 
     private void assertSameConfig(RepoConfiguration expectedRepoConfig, StandaloneConfig actualStandaloneConfig)
             throws Exception {
-        RepoConfiguration actualRepoConfig = new RepoConfiguration(new RepoLocation(TEST_DUMMY_LOCATION));
+        RepoConfiguration actualRepoConfig = new RepoConfiguration(
+                new RepoLocation(TEST_DUMMY_LOCATION, new ErrorSummary()));
         actualRepoConfig.update(actualStandaloneConfig);
         TestUtil.compareRepoConfig(expectedRepoConfig, actualRepoConfig);
     }

--- a/src/test/java/reposense/report/ErrorSummaryTest.java
+++ b/src/test/java/reposense/report/ErrorSummaryTest.java
@@ -13,39 +13,39 @@ public class ErrorSummaryTest {
         String invalidLocation2 = "https://github.com/contains-illegal-chars/^\\/";
         String invalidLocation3 = "not-valid-protocol://abc.com/reposense/RepoSense.git";
 
-        ErrorSummary errorSummaryInstance = ErrorSummary.getInstance();
+        ErrorSummary errorSummaryInstance = new ErrorSummary();
         errorSummaryInstance.clearErrorSet();
 
         try {
-            new RepoLocation(invalidLocation1);
+            new RepoLocation(invalidLocation1, errorSummaryInstance);
         } catch (InvalidLocationException e) {
             // not relevant to the test
         }
         Assertions.assertEquals(1, errorSummaryInstance.getErrorSet().size());
 
         try {
-            new RepoLocation(invalidLocation1);
+            new RepoLocation(invalidLocation1, errorSummaryInstance);
         } catch (InvalidLocationException e) {
             // not relevant to the test
         }
         Assertions.assertEquals(1, errorSummaryInstance.getErrorSet().size());
 
         try {
-            new RepoLocation(invalidLocation2);
+            new RepoLocation(invalidLocation2, errorSummaryInstance);
         } catch (InvalidLocationException e) {
             // not relevant to the test
         }
         Assertions.assertEquals(2, errorSummaryInstance.getErrorSet().size());
 
         try {
-            new RepoLocation(invalidLocation1);
+            new RepoLocation(invalidLocation1, errorSummaryInstance);
         } catch (InvalidLocationException e) {
             // not relevant to the test
         }
         Assertions.assertEquals(2, errorSummaryInstance.getErrorSet().size());
 
         try {
-            new RepoLocation(invalidLocation3);
+            new RepoLocation(invalidLocation3, errorSummaryInstance);
         } catch (InvalidLocationException e) {
             // not relevant to the test
         }

--- a/src/test/java/reposense/report/RepoClonerTest.java
+++ b/src/test/java/reposense/report/RepoClonerTest.java
@@ -22,7 +22,7 @@ public class RepoClonerTest {
     @Test
     public void repoCloner_emptyRepo_failsGracefully() throws Exception {
         RepoConfiguration emptyRepositoryRepoConfig =
-                new RepoConfiguration(new RepoLocation(TEST_REPO_EMPTY_GIT_LOCATION));
+                new RepoConfiguration(new RepoLocation(TEST_REPO_EMPTY_GIT_LOCATION, new ErrorSummary()));
 
         RepoCloner repoCloner = new RepoCloner();
         repoCloner.cloneBare(emptyRepositoryRepoConfig);
@@ -34,11 +34,12 @@ public class RepoClonerTest {
     @Test
     public void repoCloner_validRepoLocationWithRelativePathingAndSpaces_success() throws Exception {
         // Clones a test repository into the test directory for testing of relative pathing
-        RepoConfiguration tempRemoteConfiguration = new RepoConfiguration(new RepoLocation(TEST_REPO_GIT_LOCATION));
+        RepoConfiguration tempRemoteConfiguration = new RepoConfiguration(
+                new RepoLocation(TEST_REPO_GIT_LOCATION, new ErrorSummary()));
         TestRepoCloner.cloneBare(tempRemoteConfiguration, Paths.get("."), REPOCLONE_LOCAL_TEST_PATH.toString());
 
         RepoConfiguration repoWithRelativePathingAndSpacesAndEndingBackslash =
-                new RepoConfiguration(new RepoLocation(REPOCLONE_LOCAL_TEST_PATH.toString()));
+                new RepoConfiguration(new RepoLocation(REPOCLONE_LOCAL_TEST_PATH.toString(), new ErrorSummary()));
         RepoCloner repoCloner = new RepoCloner();
         repoCloner.cloneBare(repoWithRelativePathingAndSpacesAndEndingBackslash);
         Assertions.assertTrue(Files.exists(REPOCLONE_LOCAL_TEST_PATH));

--- a/src/test/java/reposense/template/GitTestTemplate.java
+++ b/src/test/java/reposense/template/GitTestTemplate.java
@@ -28,6 +28,7 @@ import reposense.model.CommitHash;
 import reposense.model.FileTypeTest;
 import reposense.model.RepoConfiguration;
 import reposense.model.RepoLocation;
+import reposense.report.ErrorSummary;
 import reposense.util.FileUtil;
 import reposense.util.TestRepoCloner;
 
@@ -138,7 +139,7 @@ public class GitTestTemplate {
     }
 
     private static RepoConfiguration newRepoConfiguration() throws Exception {
-        return new RepoConfiguration(new RepoLocation(TEST_REPO_GIT_LOCATION), "master",
+        return new RepoConfiguration(new RepoLocation(TEST_REPO_GIT_LOCATION, new ErrorSummary()), "master",
                 EXTRA_OUTPUT_FOLDER_NAME_SUPPLIER.get());
     }
 


### PR DESCRIPTION
<!--
    If this pull request fully addresses an issue, use:
    Fixes #xxxx

    If this pull request partially addresses an issue, use:
    Part of #xxxx

    If this pull request addresses multiple issues, put them in multiple lines:
    Fixes #xxxx
    Fixes #yyyy

    Format the title of the pull request with most relevant issue number as follows:
    [#xxxx] Title
-->
Fixes [#1943](https://github.com/reposense/RepoSense/issues/1943)

### Proposed commit message
<!--
    Propose a detailed commit message for this pull request within the triple backticks below.
    Wrap lines at 72 characters.

    Guide on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->
```
Make ErrorSummary non-static

ErrorSummary has to be made non-static to support concurrent runs of the app. 

Let's remove the singleton design pattern from ErrorSummary, and refactor the relevant references.
```

### Other information
<!--
    Are there other relevant information, such as special testing instructions,
    which will help the reviewer better understand the code?

    You may also include a brief description of why the problem occurred.
-->
As a result of this change, multiple instances of ErrorSummary have to be instantiated. 

It is unclear if the benefits gained from this change (i.e. faster tests after parallelising) will offset the (new and) additional overhead.
